### PR TITLE
fix: rebuild serverless-offline code coverage branch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -900,6 +900,17 @@
             "unique-string": "^1.0.0",
             "write-file-atomic": "^2.0.0",
             "xdg-basedir": "^3.0.0"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://npm.tradecast.eu:4879/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
           }
         },
         "fs-extra": {
@@ -2295,6 +2306,16 @@
         "unique-string": "^1.0.0",
         "write-file-atomic": "^2.0.0",
         "xdg-basedir": "^3.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://npm.tradecast.eu:4879/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
+          }
+        }
       }
     },
     "confusing-browser-globals": {
@@ -2547,6 +2568,23 @@
         "strip-dirs": "^2.0.0"
       },
       "dependencies": {
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://npm.tradecast.eu:4879/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "dev": true,
+          "requires": {
+            "pify": "^3.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://npm.tradecast.eu:4879/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -6730,11 +6768,11 @@
       "integrity": "sha512-lLRwNcNnkZLuv13A1FUuZRZmTWF7ro2ricYvb0L9cvBYHPvZhQdKwrYnZzi103D2XKmlVmxWpdn2wfIiOt2YEw=="
     },
     "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+      "version": "3.0.0",
+      "resolved": "https://npm.tradecast.eu:4879/make-dir/-/make-dir-3.0.0.tgz",
+      "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
       "requires": {
-        "pify": "^3.0.0"
+        "semver": "^6.0.0"
       }
     },
     "makeerror": {
@@ -7376,6 +7414,11 @@
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw=="
     },
+    "p-debounce": {
+      "version": "2.1.0",
+      "resolved": "https://npm.tradecast.eu:4879/p-debounce/-/p-debounce-2.1.0.tgz",
+      "integrity": "sha512-M9bMt62TTnozdZhqFgs+V7XD2MnuKCaz+7fZdlu2/T7xruI3uIE5CicQ0vx1hV7HIUYF0jF+4/R1AgfOkl74Qw=="
+    },
     "p-each-series": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-1.0.0.tgz",
@@ -7408,11 +7451,35 @@
         "p-limit": "^1.1.0"
       }
     },
+    "p-queue": {
+      "version": "6.2.1",
+      "resolved": "https://npm.tradecast.eu:4879/p-queue/-/p-queue-6.2.1.tgz",
+      "integrity": "sha512-wV8yC/rkuWpgu9LGKJIb48OynYSrE6lVl2Bx6r8WjbyVKrFAzzQ/QevAvwnDjlD+mLt8xy0LTDOU1freOvMTCg==",
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "p-timeout": "^3.1.0"
+      },
+      "dependencies": {
+        "eventemitter3": {
+          "version": "4.0.0",
+          "resolved": "https://npm.tradecast.eu:4879/eventemitter3/-/eventemitter3-4.0.0.tgz",
+          "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
+        }
+      }
+    },
     "p-reduce": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-reduce/-/p-reduce-1.0.0.tgz",
       "integrity": "sha1-GMKw3ZNqRpClKfgjH1ig/bakffo=",
       "dev": true
+    },
+    "p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://npm.tradecast.eu:4879/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "requires": {
+        "p-finally": "^1.0.0"
+      }
     },
     "p-try": {
       "version": "1.0.0",
@@ -8341,6 +8408,17 @@
             "unique-string": "^1.0.0",
             "write-file-atomic": "^2.0.0",
             "xdg-basedir": "^3.0.0"
+          },
+          "dependencies": {
+            "make-dir": {
+              "version": "1.3.0",
+              "resolved": "https://npm.tradecast.eu:4879/make-dir/-/make-dir-1.3.0.tgz",
+              "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+              "dev": true,
+              "requires": {
+                "pify": "^3.0.0"
+              }
+            }
           }
         },
         "get-stdin": {
@@ -9602,10 +9680,9 @@
       }
     },
     "uuid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
-      "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
-      "dev": true
+      "version": "3.4.0",
+      "resolved": "https://npm.tradecast.eu:4879/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "serverless-offline",
+  "name": "@tradecast/serverless-offline",
   "version": "5.12.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,9 @@
 {
-  "name": "serverless-offline",
+  "name": "@tradecast/serverless-offline",
+  "publishConfig": {
+    "always-auth": true,
+    "registry": "https://npm.tradecast.eu:4879"
+  },
   "version": "5.12.1",
   "description": "Emulate AWS λ and API Gateway locally when developing your Serverless project",
   "license": "MIT",
@@ -147,10 +151,14 @@
     "jsonpath-plus": "^1.1.0",
     "jsonwebtoken": "^8.5.1",
     "luxon": "^1.21.3",
+    "make-dir": "^3.0.0",
     "object.fromentries": "^2.0.1",
+    "p-debounce": "^2.1.0",
+    "p-queue": "^6.2.1",
     "semver": "^6.2.0",
     "trim-newlines": "^3.0.0",
     "update-notifier": "^3.0.1",
+    "uuid": "^3.4.0",
     "velocityjs": "^1.1.5"
   },
   "devDependencies": {

--- a/src/ApiGateway.js
+++ b/src/ApiGateway.js
@@ -8,7 +8,7 @@ const h2o2 = require('@hapi/h2o2');
 
 // Coverage dependencies
 const util = require('util');
-const pQueue = require('p-queue');
+const {default: PQueue} = require('p-queue');
 const pDebounce = require('p-debounce');
 const makeDir = require('make-dir');
 const uuid = require('uuid/v4');
@@ -42,7 +42,7 @@ module.exports = class ApiGateway {
 
     if (this.shouldOutputCoverage) {
       debugLog(`Code coverage will be written to ${this.coverageTempDir}`);
-      this.coverageQueue = new pQueue({ concurrency: 1 }); // eslint-disable-line new-cap
+      this.coverageQueue = new PQueue({ concurrency: 1 }); // eslint-disable-line new-cap
       this.outputCoverage = pDebounce(
         (coverageData) =>
           this.coverageQueue.add(async () => {


### PR DESCRIPTION
Copied functionality from #1 to an updated `master` branch.
`serverless-offline` moved a lot of code from `ServerlessOffline.js` to `ApiGateway.js`, so the code coverage has been moved there.

TODO:
- [x] Test locally, which probably needs to include a newer version of `serverless`
- [x] Publish to npm.tradecast.eu
- [ ] Determine how to keep an updated version of `serverless-offline` in the future